### PR TITLE
Watchify errors handling

### DIFF
--- a/generators/app/templates/gulp/helpers.js
+++ b/generators/app/templates/gulp/helpers.js
@@ -1,10 +1,12 @@
 'use strict';
 
+// Globally omit stack trace
+Error.stackTraceLimit = 0;
 var helpers = function (gulp, plugins, config) {
   return {
     onError: function (error) {
       console.error(error.message + '\n');
-      console.error(error.fileName + ':' + error.lineNumber + '\n');
+      console.error(error.stack + '\n');
 
       this.emit('end');
     }

--- a/generators/app/templates/gulp/tasks/scripts.js
+++ b/generators/app/templates/gulp/tasks/scripts.js
@@ -5,7 +5,9 @@ var scriptsTask = function (gulp, plugins, config, helpers) {
     var props = {
       entries: config.src.app,
       debug: true,
+      <% if(features.has_babel) { %>
       transform: [["babelify", { "presets": ["es2015"] }]]
+      <% } %>
     };
 
     var bundler = watch ? plugins.watchify(plugins.browserify(props)) : plugins.browserify(props);
@@ -23,20 +25,13 @@ var scriptsTask = function (gulp, plugins, config, helpers) {
         .pipe(plugins.browserSync.stream());
     }
 
-    bundler.on('update', () => {
-      rebundle();
-    })
+    bundler.on('update', rebundle);
 
     return rebundle();
   }
 
-  gulp.task('scripts', () => {
-      return buildScript(false);
-  });
-
-  gulp.task('watchify', ['scripts'], () => {
-    return buildScript(true);
-  });
+  gulp.task('scripts', () => buildScript(false));
+  gulp.task('watchify', ['scripts'], () => buildScript(true));
 };
 
 module.exports = scriptsTask;

--- a/generators/app/templates/gulp/tasks/scripts.js
+++ b/generators/app/templates/gulp/tasks/scripts.js
@@ -1,44 +1,41 @@
 'use strict';
 
 var scriptsTask = function (gulp, plugins, config, helpers) {
+  function buildScript(watch) {
+    var props = {
+      entries: config.src.app,
+      debug: true,
+      transform: [["babelify", { "presets": ["es2015"] }]]
+    };
 
-  var customOpts = {
-    entries: config.src.app,
-    debug: true
-  };
+    var bundler = watch ? plugins.watchify(plugins.browserify(props)) : plugins.browserify(props);
 
-  function bundle(bundler) {
-    return bundler<% if (features.has_babel) { %>
-      .transform("babelify", { presets: ["es2015"] })<% } %>
-      .bundle()
-      .pipe(plugins.vinylSourceStream('bundle.js'))
-      .pipe(plugins.vinylBuffer())
-      .pipe(plugins.sourcemaps.init({loadMaps: true}))
-      .pipe(plugins.uglify())
-      .on('error', helpers.onError)
-      .pipe(plugins.sourcemaps.write('./'))
-      .pipe(gulp.dest(config.dest.scripts))
-      .pipe(plugins.browserSync.stream());
+    function rebundle() {
+      var stream = bundler.bundle();
+      return stream
+        .on('error', helpers.onError)
+        .pipe(plugins.vinylSourceStream('bundle.js'))
+        .pipe(plugins.vinylBuffer())
+        .pipe(plugins.sourcemaps.init({loadMaps: true}))
+        .pipe(plugins.uglify())
+        .pipe(plugins.sourcemaps.write('./'))
+        .pipe(gulp.dest(config.dest.scripts))
+        .pipe(plugins.browserSync.stream());
+    }
+
+    bundler.on('update', () => {
+      rebundle();
+    })
+
+    return rebundle();
   }
 
-  gulp.task('scripts-build', ['lint-js', 'styles-build'], function () {
-    return bundle(plugins.browserify(customOpts))
-      .pipe(plugins.rev())
-      .pipe(gulp.dest(config.dest.scripts))
-      .pipe(plugins.rev.manifest({
-        path: config.dest.revManifest,
-        base: config.dest.base,
-        merge: true
-      }))
-      .pipe(gulp.dest(config.dest.base));
+  gulp.task('scripts', () => {
+      return buildScript(false);
   });
 
-  gulp.task('watchify', function () {
-    var watcher = plugins.watchify(plugins.browserify(customOpts, plugins.watchify.args));
-    bundle(watcher);
-    watcher.on('update', function () {
-      bundle(watcher);
-    })
+  gulp.task('watchify', ['scripts'], () => {
+    return buildScript(true);
   });
 };
 

--- a/generators/app/templates/gulp/tasks/templates.js
+++ b/generators/app/templates/gulp/tasks/templates.js
@@ -32,7 +32,7 @@ var templatesTask = function (gulp, plugins, config, helpers) {
     templates();
   });
 
-  gulp.task('templates-build', ['scripts-build'], function() {
+  gulp.task('templates-build', ['scripts'], function() {
     var manifest = JSON.parse(fs.readFileSync(config.dest.revManifest, 'utf8'));
     templates(manifest);
   });

--- a/test/app/babel.test.js
+++ b/test/app/babel.test.js
@@ -30,7 +30,7 @@ describe('Chisel Generator with ES2015 and Babel', function () {
 
   it('should add Babelify transform to the Gulp scripts task', function (done) {
     assert.file('gulp/tasks/scripts.js');
-    assert.fileContent('gulp/tasks/scripts.js', '.transform("babelify", { presets: ["es2015"] })');
+    assert.fileContent('gulp/tasks/scripts.js', 'transform: [["babelify", { "presets": ["es2015"] }]]');
 
     done();
   });


### PR DESCRIPTION
When watching scripts, Chisel silences errors which come from `watchify`, which is not really helpful while development. This PR attempts to handle these errors.

Preview of an error:
![screen shot 2016-09-15 at 1 47 51 pm](https://cloud.githubusercontent.com/assets/13747302/18548863/56db470a-7b4b-11e6-884b-44c72c6e0802.png)
