### PR TITLE
Don't break the build after linting errors

### DIFF
--- a/generators/app/templates/gulp/tasks/lint.js
+++ b/generators/app/templates/gulp/tasks/lint.js
@@ -11,6 +11,7 @@ var lintTask = function (gulp, plugins, config) {
   gulp.task('lint-css', function() {
     return gulp.src(config.src.styles)
       .pipe(plugins.stylelint({
+        failAfterError: false,
         reporters: [
           {formatter: 'string', console: true}
         ]


### PR DESCRIPTION
Hey guys,
I suggest we let the build pass even with linting errors.
Code style issues aren't that important and our linter is currently very restrictive.

This still outputs errors in console, but the build process doesn't fail after linting.
Does this sound reasonable?

D.