### PR TITLE
Fix task order in build

### DIFF
--- a/generators/app/templates/gulp/tasks/build.js
+++ b/generators/app/templates/gulp/tasks/build.js
@@ -6,7 +6,7 @@ var buildTask = function (gulp, plugins, config) {
     return plugins.del([config.dest.base]);
   });
 
-  gulp.task('build', plugins.sequence('lint-js', 'scripts-build', 'styles-build', 'templates-build', 'validate-html'))
+  gulp.task('build', plugins.sequence('styles-build', 'lint-js', 'scripts-build', 'templates-build', 'validate-html'))
 };
 
 module.exports = buildTask;

--- a/generators/app/templates/gulp/tasks/styles.js
+++ b/generators/app/templates/gulp/tasks/styles.js
@@ -29,7 +29,11 @@ var stylesTask = function (gulp, plugins, config, helpers) {
       .pipe(plugins.sourcemaps.write('./'))
       .pipe(plugins.rev())
       .pipe(gulp.dest(config.dest.styles))
-      .pipe(plugins.rev.manifest())
+      .pipe(plugins.rev.manifest({
+        path: config.dest.revManifest,
+        base: config.dest.base,
+        merge: true
+      }))
       .pipe(gulp.dest(config.dest.base))
       .pipe(plugins.browserSync.stream());
   });


### PR DESCRIPTION
With current order styles-build overwrites `rev-manifest.json` created by scripts-build. In the effect there is no info about `bundle.js` name and builded templates has line like: `<script src="scripts/" async></script>`. Currently released version of Chisel is unusable.