### PR TITLE
Remove media=screen from styles

### DIFF
--- a/generators/app/templates/templates/twig/_base.twig
+++ b/generators/app/templates/templates/twig/_base.twig
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>{{ pageName }} - <%= name %></title>
-  <link rel="stylesheet" property="stylesheet" href="styles/{{ assetPath('main.css') }}" type="text/css" media="screen">
+  <link rel="stylesheet" property="stylesheet" href="styles/{{ assetPath('main.css') }}" type="text/css">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>document.querySelector('html').classList.remove('no-js');</script>
 </head>


### PR DESCRIPTION
What is better than printing with mobile styles? Printing without styles.