### PR TITLE
Template task: Fix unprefixed template watch and build globs

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -16,12 +16,12 @@
       "styles": "styles/**/*",
       "stylesMain": "styles/*.scss",
       "templatesBuild": [
-        "templates/*.{twig,html}",
+        "src/templates/*.{twig,html}",
         "!**/_*.{twig,html}"
       ],
       "templatesWatch": [
-        "templates/**/*.{twig,html}",
-        "data/**.json"
+        "src/templates/**/*.{twig,html}",
+        "src/data/**.json"
       ],
       "templatesPath": "templates/"
     },


### PR DESCRIPTION
Hey.
Seems like in current version of the generator, the paths (globs) to our template directories are messed up.
This was probably introduced when we decided to extract our base path (`src/`) to separate variable, but forgot about the way the template paths are being handled in task script.

Here's my simple fix, which brings back the prefixes to our `package.json` configuration (in template globs).
I know it doesn't look that great and I've thought about traversing our config array to prefix them with our base path, but there's a case here with negative glob (`!**/_*.{twig,html}`) which would require more complex handling than just concating available variables.
I'm not sure if introducing such complexity to our tasks would be beneficial in the long run...
What's your take on this @luboskmetko @jakub300 @thymikee ?