### PR TITLE
Don’t require viewBox html attribute to be lowercase

### DIFF
--- a/generators/app/templates/.htmlhintrc
+++ b/generators/app/templates/.htmlhintrc
@@ -1,0 +1,3 @@
+{
+  "attr-lowercase": ["viewBox"]
+}

--- a/generators/app/templates/gulp/tasks/lint.js
+++ b/generators/app/templates/gulp/tasks/lint.js
@@ -21,7 +21,7 @@ var lintTask = function (gulp, plugins, config) {
 
   gulp.task('validate-html', function() {
     return gulp.src(config.dest.base + '/**/*.html')
-      .pipe(plugins.htmlhint())
+      .pipe(plugins.htmlhint('.htmlhintrc'))
       .pipe(plugins.htmlhint.reporter())
   });
 };


### PR DESCRIPTION
Fixes #129