### PR TITLE
Fix stylelint to 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - v7
-  - v6
-  - v4
+  - "7"
+  - "6"
+  - "4"
 addons:
   apt:
     packages:
@@ -14,9 +14,9 @@ before_install:
   - npm install -g yo
 matrix:
   include:
-    - node_js: v6
+    - node_js: "6"
       env: TEST_VERSIONS=generator
-    - node_js: v6
+    - node_js: "6"
       env: TEST_VERSIONS=generated_project
   allow_failures:
     - env: TEST_VERSIONS=generator

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -60,7 +60,7 @@
     "gulp-sass-glob": "^1.0.6",
     "gulp-sequence": "^0.4.6",
     "gulp-sourcemaps": "^2.1.1",
-    "gulp-stylelint": "^3.4.0",<% if (projectType == 'fe') { %>
+    "gulp-stylelint": "3.5.0",<% if (projectType == 'fe') { %>
     "gulp-twig-up-to-date": "^0.6.1",<% } %>
     "gulp-uglify": "^2.0.0",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
**Summary**

`gulp-stylelint` v3.6 has a bug, where warnings are treated like errors and crash whole gulp task. Relevant issue: https://github.com/olegskl/gulp-stylelint/issues/60