### PR TITLE
Remove template related things from WordPress projects

### DIFF
--- a/generators/app/templates/gulp/tasks/build.js
+++ b/generators/app/templates/gulp/tasks/build.js
@@ -6,7 +6,11 @@ var buildTask = function (gulp, plugins, config) {
     return plugins.del([config.dest.base]);
   });
 
+  <% if(projectType == 'wp-with-fe') { %>
+  gulp.task('build', plugins.sequence('styles-build', 'lint-js', 'scripts-build'))
+  <% } else { %>
   gulp.task('build', plugins.sequence('styles-build', 'lint-js', 'scripts-build', 'templates-build', 'validate-html'))
+  <% } %>
 };
 
 module.exports = buildTask;

--- a/generators/app/templates/gulp/tasks/serve.js
+++ b/generators/app/templates/gulp/tasks/serve.js
@@ -3,7 +3,12 @@
 var path = require('path');
 
 var serveTask = function (gulp, plugins, config, helpers, generator_config) {
-  gulp.task('serve', ['styles-watch', 'templates-watch', 'assets-watch'], function() {
+  <% if(projectType == 'wp-with-fe') { %>
+  var startTasks = ['styles-watch', 'assets-watch'];
+  <% } else { %>
+  var startTasks = ['styles-watch', 'templates-watch', 'assets-watch'];
+  <% } %>
+  gulp.task('serve', startTasks, function() {
     <% if(projectType == 'wp-with-fe') { %>
     var name = generator_config.nameSlug;
     var browserSyncConfig = {
@@ -24,7 +29,9 @@ var serveTask = function (gulp, plugins, config, helpers, generator_config) {
     plugins.browserSync.init(browserSyncConfig);
 
     gulp.watch(path.join(config.src.base, config.src.styles), ['styles-watch']);
+    <% if(projectType == 'fe') { %>
     gulp.watch(config.src.templatesWatch, ['templates-watch']);
+    <% } %>
     gulp.watch(path.join(config.src.base, config.src.assets), ['assets-watch']);
     <% if(projectType == 'wp-with-fe') { %>
     gulp.watch('**/*.{php,twig}').on('change', plugins.browserSync.reload);


### PR DESCRIPTION
Currently neither `gulp` not `gulp build` work on WP projects because they try to ron tasks that depend on TWIG that we removed from WordPress projects.