### PR TITLE
WiP: Add tests for gulp tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ npm-debug.log
 .vagrant
 
 helpers/wp-cli.phar
+test/generated_project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 language: node_js
 node_js:
   - "7"
@@ -8,9 +10,8 @@ addons:
     packages:
       - php5-cli
       - php5-mysql
-services:
-  - mysql
 before_install:
+  - mysql -e 'SET PASSWORD FOR "root"@"localhost" = PASSWORD("");' -uroot
   - npm install -g yo
 matrix:
   include:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   },
   "devDependencies": {
     "cross-spawn": "^5.0.1",
-    "mocha": "^2.5.3"
+    "json-stream": "^1.0.0",
+    "mocha": "^2.5.3",
+    "phantomjs-prebuilt": "^2.1.13"
   },
   "repository": "git@github.com:xfiveco/generator-chisel.git",
   "license": "MIT"

--- a/test/generate_package.js
+++ b/test/generate_package.js
@@ -1,7 +1,3 @@
-if(!process.env['TEST_VERSIONS'] || process.env['TEST_VERSIONS'] != 'generated_project') {
-  return;
-}
-
 var fs = require('fs');
 var ejs = require('ejs');
 

--- a/test/gulp-fe/gulp.browsersync.test.js
+++ b/test/gulp-fe/gulp.browsersync.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var path = require('path');
+var yeoman = require('yeoman-generator');
+var helpers = require('yeoman-test');
+var assert = require('yeoman-assert');
+var cp = require('child_process');
+var fs = require('fs');
+var async = require('async');
+var prepare = require('../prepare_gulp_env.js');
+var PhantomInstance = require('../helpers/PhantomInstance');
+var phantom = new PhantomInstance();
+var GulpInstance = require('../helpers/GulpInstance');
+var gulp = new GulpInstance();
+
+describe('Gulp build on Chisel Generator with default options (BrowserSync tests)', function () {
+  this.timeout(30000);
+
+  before(function (done) {
+    this.timeout(240000);
+    prepare.prepare();
+
+      async.series([
+        function(callback) {
+          helpers
+            .run(path.join(__dirname, '../../generators/app'))
+            .withOptions({
+              'skip-install': true
+            })
+            .withPrompts({
+              name: 'Test Project',
+              author: 'Test Author',
+              features: [],
+              projectType: 'fe'
+            })
+            .on('end', () => {
+              cp.execSync('ln -s '+prepare.getNodeModules()+' node_modules');
+              callback();
+            });
+        },
+        function(callback) {
+          helpers
+            .run(path.join(__dirname, '../../generators/page'), { tmpdir: false })
+            .withArguments(['Page1'])
+            .withOptions({
+              'skip-build': true
+            })
+            .on('ready', function (generator) {
+              generator.conflicter.force = true;
+            })
+            .on('end', callback);
+        },
+        function(callback) {
+          var fileName = 'src/scripts/greeting.js';
+          var file = fs.readFileSync(fileName, 'utf8');
+          file +=
+            fs.readFileSync(path.join(__dirname, '../helpers/phantom_inject.js'))
+              .toString('utf8');
+          fs.writeFileSync(fileName, file);
+          callback();
+        },
+        function(callback) {
+          gulp.start();
+          gulp.once('ready', () => {
+            phantom.start(gulp.localUrl+'/dist/page-1.html');
+            phantom.once('bsConnected', callback);
+          })
+        },
+        (cb) => global.setTimeout(cb, 5000) // TODO: remove
+      ], done);
+  });
+
+  it('should reload on modified page', function (done) {
+    var fileName = 'src/templates/page-1.twig';
+    var file = fs.readFileSync(fileName, 'utf8');
+    file = file.replace('js-greeting', 'js-greeting js-greeting-modified');
+    fs.writeFileSync(fileName, file);
+
+    phantom.once('urlChanged', () => {
+      assert.fileContent('dist/page-1.html', 'js-greeting-modified');
+      phantom.once('bsConnected', done);
+    });
+  });
+
+  require('../helpers/gulp.browsersync.shared.js')
+    (phantom, 'src', 'dist');
+
+  after(function(done) {
+    gulp.stop();
+    phantom.stop();
+    done();
+  });
+
+
+});

--- a/test/gulp-fe/gulp.build.double.test.js
+++ b/test/gulp-fe/gulp.build.double.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var path = require('path');
+var yeoman = require('yeoman-generator');
+var helpers = require('yeoman-test');
+var assert = require('yeoman-assert');
+var cp = require('child_process');
+var fs = require('fs');
+var prepare = require('../prepare_gulp_env.js');
+
+describe('Gulp build (double) on Chisel Generator with default options', function () {
+  before(function (done) {
+    this.timeout(240000);
+    prepare.prepare();
+
+    helpers
+      .run(path.join(__dirname, '../../generators/app'))
+      .withOptions({
+        'skip-install': true
+      })
+      .withPrompts({
+        name: 'Test Project',
+        author: 'Test Author',
+        features: [],
+        projectType: 'fe'
+      })
+      .on('end', () => {
+        cp.execSync('ln -s '+prepare.getNodeModules()+' node_modules');
+        fs.writeFileSync('src/assets/test.txt', 'abcd-tessst');
+        cp.execSync('gulp build');
+        fs.unlinkSync('src/assets/test.txt');
+        fs.writeFileSync('src/assets/test2.txt', 'abcd-tessst-seeecond');
+        cp.execSync('gulp build');
+        done();
+      });
+  });
+
+  it('should remove old assets', function (done) {
+    assert.noFile('dist/assets/test.txt');
+
+    done();
+  });
+
+  it('should copy assets', function (done) {
+    assert.fileContent('dist/assets/test2.txt', 'abcd-tessst-seeecond');
+
+    done();
+  });
+
+});

--- a/test/gulp-fe/gulp.build.test.js
+++ b/test/gulp-fe/gulp.build.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var path = require('path');
+var yeoman = require('yeoman-generator');
+var helpers = require('yeoman-test');
+var assert = require('yeoman-assert');
+var cp = require('child_process');
+var fs = require('fs');
+var prepare = require('../prepare_gulp_env.js');
+
+describe('Gulp build on Chisel Generator with default options', function () {
+  before(function (done) {
+    this.timeout(240000);
+    prepare.prepare();
+
+    helpers
+      .run(path.join(__dirname, '../../generators/app'))
+      .withOptions({
+        'skip-install': true
+      })
+      .withPrompts({
+        name: 'Test Project',
+        author: 'Test Author',
+        features: [],
+        projectType: 'fe'
+      })
+      .on('end', () => {
+        cp.execSync('ln -s '+prepare.getNodeModules()+' node_modules');
+        fs.writeFileSync('src/assets/test.txt', 'abcd-tessst');
+        cp.execSync('gulp build');
+        done();
+      });
+  });
+
+  require('../helpers/gulp.build.shared.js')('dist');
+
+});

--- a/test/gulp-wp-with-fe/gulp.browsersync.test.js
+++ b/test/gulp-wp-with-fe/gulp.browsersync.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+var path = require('path');
+var async = require('async');
+var yeoman = require('yeoman-generator');
+var helpers = require('yeoman-test');
+var assert = require('yeoman-assert');
+var cp = require('child_process');
+var fs = require('fs');
+var prepare = require('../prepare_gulp_env.js');
+var PhantomInstance = require('../helpers/PhantomInstance');
+var phantom = new PhantomInstance();
+var GulpInstance = require('../helpers/GulpInstance');
+var gulp = new GulpInstance();
+var PhpServerInstance = require('../helpers/PhpServerInstance');
+var phpServer = new PhpServerInstance();
+
+describe('Browsersync and gulp tests on WordPress project', function () {
+  this.timeout(30000);
+
+  before(function (done) {
+    this.timeout(240000);
+    prepare.prepare();
+
+    async.series([
+      function (callback) {
+        helpers
+          .run(path.join(__dirname, '../../generators/app'))
+          .withOptions({
+            'skip-install': true,
+            'run-wp': true
+          })
+          .withPrompts({
+            name: 'Test Browsersync WP',
+            author: 'Test Author',
+            projectType: 'wp-with-fe',
+            features: [],
+            url: 'http://localhost:8080/',
+            databasePassword: new String(''),
+            adminPassword: 'pass',
+            adminEmail: 'user@example.com',
+            plugins: []
+          })
+          .on('end', callback);
+      },
+      function(callback) {
+        helpers
+          .run(path.join(__dirname, '../../generators/page'), { tmpdir: false })
+          .withArguments(['Testing Page'])
+          .withOptions({
+            'skip-build': true
+          })
+          .on('ready', function (generator) {
+            generator.conflicter.force = true;
+          })
+          .on('end', callback);
+      },
+      function(callback) {
+        var fileName = 'src/scripts/greeting.js';
+        var file = fs.readFileSync(fileName, 'utf8');
+        file +=
+          fs.readFileSync(path.join(__dirname, '../helpers/phantom_inject.js'))
+            .toString('utf8');
+        fs.writeFileSync(fileName, file);
+
+        fileName = '.yo-rc.json';
+        file = fs.readFileSync(fileName, 'utf8');
+        file = JSON.parse(file);
+        file['generator-chisel'].config.proxyTarget = 'http://localhost:8080/';
+        file = JSON.stringify(file, null, '  ');
+        fs.writeFileSync(fileName, file);
+
+        cp.execSync('ln -s '+prepare.getNodeModules()+' node_modules');
+        callback();
+      },
+      function(callback) {
+        phpServer.start();
+        setTimeout(callback, 2000);
+      },
+      function(callback) {
+        gulp.start();
+        gulp.once('ready', () => {
+          phantom.start(gulp.localUrl+'/');
+          phantom.once('bsConnected', callback);
+        })
+      }
+    ], done);
+  });
+
+  it('should reload on modified page', function (done) {
+    var fileName = 'wp/wp-content/themes/test-browsersync-wp/templates/page-testing-page.twig';
+    var file = fs.readFileSync(fileName, 'utf8');
+    file = file.replace('id="post-', 'id="testing-post-');
+    fs.writeFileSync(fileName, file);
+
+    phantom.once('urlChanged', () => {
+      phantom.once('bsConnected', done);
+    });
+  });
+
+  require('../helpers/gulp.browsersync.shared.js')
+    (phantom, 'src', 'wp/wp-content/themes/test-browsersync-wp/dist');
+
+  after(function(done) {
+    gulp.stop();
+    phantom.stop();
+    phpServer.stop();
+    done();
+  });
+
+});

--- a/test/gulp-wp-with-fe/gulp.build.test.js
+++ b/test/gulp-wp-with-fe/gulp.build.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var path = require('path');
+var async = require('async');
+var yeoman = require('yeoman-generator');
+var helpers = require('yeoman-test');
+var assert = require('yeoman-assert');
+var cp = require('child_process');
+var fs = require('fs');
+var prepare = require('../prepare_gulp_env.js');
+
+describe('Gulp build on Chisel Generator (WordPress)', function () {
+  before(function (done) {
+    this.timeout(240000);
+    prepare.prepare();
+
+    async.series([
+      function (callback) {
+        helpers
+          .run(path.join(__dirname, '../../generators/app'))
+          .withOptions({
+            'skip-install': true,
+            'run-wp': true
+          })
+          .withPrompts({
+            name: 'Test Gulp WP Build',
+            author: 'Test Author',
+            projectType: 'wp-with-fe',
+            features: [],
+            databasePassword: new String(''),
+            adminPassword: 'pass',
+            adminEmail: 'user@example.com',
+            plugins: []
+          })
+          .on('end', callback);
+      },
+      function (callback) {
+        cp.execSync('ln -s '+prepare.getNodeModules()+' node_modules');
+        fs.writeFileSync('src/assets/test.txt', 'abcd-tessst');
+        cp.execSync('gulp build');
+        callback();
+      }
+    ], done);
+  });
+
+  require('../helpers/gulp.build.shared.js')('wp/wp-content/themes/test-gulp-wp-build/dist');
+
+});

--- a/test/helpers/GulpInstance.js
+++ b/test/helpers/GulpInstance.js
@@ -1,0 +1,32 @@
+var util = require('util');
+var ProcessInstance = require('./ProcessInstance');
+
+var gulpUrl = /Local: (http[^\s]+)/;
+
+function GulpInstance() {
+  ProcessInstance.call(this);
+
+  this.localUrl = null;
+}
+util.inherits(GulpInstance, ProcessInstance);
+
+GulpInstance.prototype.start = function() {
+  var gulpProcess = this._start('gulp', [], {stdio: ['ignore', 'pipe', 'inherit']})
+
+  var buffer = new Buffer([]);
+  var gulpListener = (data) => {
+    buffer = Buffer.concat([buffer, data]);
+    var str = buffer.toString('utf8');
+    if(str.indexOf('Finished \'default\'') != -1) {
+      gulpProcess.stdout.removeListener('data', gulpListener);
+      this.localUrl = gulpUrl.exec(str)[1];
+      this.emit('ready');
+    }
+  }
+  gulpProcess.stdout.on('data', (data) => process.stdout.write(data));
+  gulpProcess.stdout.on('data', gulpListener);
+}
+
+GulpInstance.prototype.stop = ProcessInstance.prototype._stop;
+
+module.exports = GulpInstance;

--- a/test/helpers/PhantomInstance.js
+++ b/test/helpers/PhantomInstance.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var phantom = require('phantomjs-prebuilt').path;
+var path = require('path');
+var util = require('util');
+var JSONStream = require('json-stream');
+var ProcessInstance = require('./ProcessInstance');
+
+function PhantomInstance() {
+  ProcessInstance.call(this);
+
+  this.isRunning = false;
+  this.jsonStream = null;
+}
+util.inherits(PhantomInstance, ProcessInstance);
+
+PhantomInstance.prototype.start = function(url) {
+  if(this.isRunning) {
+    return;
+  }
+  this._start(phantom, [path.join(__dirname, 'phantom_logger.js'), url], {
+    stdio: ['ignore', 'pipe', 'inherit']
+  });
+  this.process.stdout.on('data', (data) => process.stdout.write(data));
+  this.isRunning = true;
+
+  this._startJSONStream();
+}
+
+PhantomInstance.prototype._startJSONStream = function() {
+  var jsonStream = this.jsonStream = JSONStream();
+  jsonStream.on('data', this._jsonStreamData.bind(this));
+  this.process.stdout.pipe(jsonStream);
+}
+
+PhantomInstance.prototype._jsonStreamData = function(data) {
+  if(data.kind) {
+    this.emit(data.kind, data);
+    if(data.kind == 'bsNotify' && data.text == 'Connected to BrowserSync') {
+      this.emit('bsConnected');
+    }
+  }
+}
+
+PhantomInstance.prototype.stop = ProcessInstance.prototype._stop;
+
+module.exports = PhantomInstance;

--- a/test/helpers/PhpServerInstance.js
+++ b/test/helpers/PhpServerInstance.js
@@ -1,0 +1,18 @@
+var util = require('util');
+var ProcessInstance = require('./ProcessInstance');
+
+function PhpServerInstance() {
+  ProcessInstance.call(this);
+
+  this.localUrl = null;
+}
+util.inherits(PhpServerInstance, ProcessInstance);
+
+PhpServerInstance.prototype.start = function() {
+  this._start('php', ['-S', '127.0.0.1:8080', '-t', 'wp'],
+    {stdio: ['ignore', 'inherit', 'inherit']});
+}
+
+PhpServerInstance.prototype.stop = ProcessInstance.prototype._stop;
+
+module.exports = PhpServerInstance;

--- a/test/helpers/ProcessInstance.js
+++ b/test/helpers/ProcessInstance.js
@@ -1,0 +1,30 @@
+var EventEmitter = require('events');
+var util = require('util');
+var spawn = require('cross-spawn');
+
+function ProcessInstance() {
+  EventEmitter.call(this);
+
+  this.process = null;
+}
+util.inherits(ProcessInstance, EventEmitter);
+
+ProcessInstance.prototype._start = function(name, args, options) {
+  this.process = spawn(name, args, options);
+  return this.process;
+}
+
+ProcessInstance.prototype._stop = function(cb) {
+  cb = cb || function() {};
+  if(!this.process) {
+    cb('Not started');
+    return;
+  }
+  if(cb) {
+    this.process.once('close', cb);
+  }
+  this.process.once('close', () => this.emit('stop'));
+  this.process.kill();
+}
+
+module.exports = ProcessInstance;

--- a/test/helpers/gulp.browsersync.shared.js
+++ b/test/helpers/gulp.browsersync.shared.js
@@ -1,0 +1,32 @@
+var assert = require('yeoman-assert');
+var fs = require('fs');
+
+function addTests(phantom, srcDir, distDir) {
+  it('should reload on modified script', function (done) {
+    var fileName = srcDir+'/scripts/greeting.js';
+    var file = fs.readFileSync(fileName, 'utf8');
+    file = file.replace('= name', '= "xfive tests js"');
+    fs.writeFileSync(fileName, file);
+
+    phantom.once('urlChanged', () => {
+      assert.fileContent(distDir+'/scripts/bundle.js', 'xfive tests js');
+      assert.fileContent(distDir+'/scripts/bundle.js.map', 'xfive tests js');
+      phantom.once('bsConnected', done);
+    });
+  });
+
+  it('should inject modified CSS file', function(done) {
+    var fileName = srcDir+'/styles/elements/_headings.scss';
+    var file = fs.readFileSync(fileName, 'utf8');
+    file += 'h1 {color: red;}'
+    fs.writeFileSync(fileName, file);
+    phantom.once('bsNotify', (msg) => {
+      assert.fileContent(distDir+'/styles/main.css', 'color: red;');
+      assert.fileContent(distDir+'/styles/main.css.map', 'h1 {color: red;}');
+      assert.deepEqual(msg, {"kind":"bsNotify","text":"Injected: main.css"});
+      done();
+    });
+  });
+}
+
+module.exports = addTests;

--- a/test/helpers/gulp.build.shared.js
+++ b/test/helpers/gulp.build.shared.js
@@ -1,0 +1,54 @@
+var assert = require('yeoman-assert');
+var fs = require('fs');
+
+function addTests(dist) {
+  it('should generate proper rev-manifest.json', function (done) {
+    assert.file(dist+'/rev-manifest.json');
+    assert.fileContent(dist+'/rev-manifest.json', '"bundle.js"');
+    assert.fileContent(dist+'/rev-manifest.json', '"bundle.js.map"');
+    assert.fileContent(dist+'/rev-manifest.json', '"main.css"');
+    assert.fileContent(dist+'/rev-manifest.json', '"main.css.map"');
+
+    assert.fileContent(dist+'/rev-manifest.json', /"bundle-[0-9a-z]+\.js"/);
+    assert.fileContent(dist+'/rev-manifest.json', /"bundle-[0-9a-z]+\.js\.map"/);
+    assert.fileContent(dist+'/rev-manifest.json', /"main-[0-9a-z]+\.css"/);
+    assert.fileContent(dist+'/rev-manifest.json', /"main-[0-9a-z]+\.css\.map"/);
+
+    done();
+  });
+
+  it('should generate styles', function (done) {
+    var manifest = JSON.parse(fs.readFileSync(dist+'/rev-manifest.json'));
+    var cssFile = dist+'/styles/'+manifest['main.css'];
+
+    // contains normalize-scss, _list-bare
+    assert.fileContent(cssFile, 'bit.ly/normalize-scss');
+    assert.fileContent(cssFile, '.o-list-bare');
+
+    // contains sourcemap
+    assert.fileContent(cssFile, '/*# sourceMappingURL='+manifest['main.css.map']+' */');
+
+    done();
+  });
+
+  it('should generate script', function (done) {
+    var manifest = JSON.parse(fs.readFileSync(dist+'/rev-manifest.json'));
+    var jsFile = dist+'/scripts/'+manifest['bundle.js'];
+
+    // contains greeting
+    assert.fileContent(jsFile, 'document.querySelector(".js-greeting").innerHTML');
+
+    // contains sourcemap
+    assert.fileContent(jsFile, '//# sourceMappingURL='+manifest['bundle.js.map']);
+
+    done();
+  });
+
+  it('should copy assets', function (done) {
+    assert.fileContent(dist+'/assets/test.txt', 'abcd-tessst');
+
+    done();
+  });
+}
+
+module.exports = addTests;

--- a/test/helpers/phantom_inject.js
+++ b/test/helpers/phantom_inject.js
@@ -1,0 +1,37 @@
+(function() {
+  var element = null;
+
+  var observerNewNode = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+      if(!mutation.addedNodes.length) {
+        return;
+      }
+      var addedNode = mutation.addedNodes[0];
+      if(addedNode.id == '__bs_notify__') {
+        window.callPhantom({kind: 'bsNotify', text: addedNode.textContent.trim()})
+        element = addedNode;
+        observerText.observe(element, {characterData: true, subtree: true});
+        observerNewNode.disconnect();
+      };
+    })
+  })
+
+  var observerText = new MutationObserver(function(mutations) {
+    var parent = mutations[0].target.parentNode;
+    if(parent.id != '__bs_notify__') {
+      return;
+    }
+    window.callPhantom({kind: 'bsNotify', text: parent.textContent.trim()});
+  })
+
+  observerNewNode.observe(document.body, {childList: true});
+
+  window.addEventListener('load', function() {
+    window.callPhantom({kind: 'loadedInside'});
+  })
+
+  if(!window.callPhantom) {
+    window.callPhantom = console.log.bind(console);
+  }
+  window.callPhantom({kind: 'hello'});
+})();

--- a/test/helpers/phantom_logger.js
+++ b/test/helpers/phantom_logger.js
@@ -1,0 +1,28 @@
+var system = require('system');
+var args = system.args;
+
+var page = require('webpage').create();
+
+page.onCallback = function(data) {
+  show(data);
+}
+
+page.onUrlChanged = function(url) {
+  show({kind: 'urlChanged', url: url})
+}
+
+page.onConsoleMessage = function(a, b, c) {
+  console.log('console', a, b, c);
+}
+
+page.onError = function(a, b) {
+  console.log('error', a, b);
+}
+
+page.open(args[1], function(success) {
+  show({kind: 'loaded', success: success});
+});
+
+function show(data) {
+  console.log(JSON.stringify(data));
+}

--- a/test/prepare_gulp_env.js
+++ b/test/prepare_gulp_env.js
@@ -1,0 +1,27 @@
+var cp = require('child_process');
+var path = require('path');
+
+var node_modules = '';
+
+exports.prepare = function() {
+  if(process.env.CHISEL_MODULES || node_modules) {
+    return;
+  }
+  var initialCwd = path.join(__dirname, '..');
+  process.chdir(initialCwd);
+  cp.execSync('npm install gulp-cli ejs');
+  process.chdir(path.join(initialCwd, 'test'));
+  cp.execSync('mkdir -p generated_project');
+  cp.execSync('node generate_package.js');
+  process.chdir(path.join(initialCwd, 'test/generated_project'));
+  cp.execSync('npm install');
+  node_modules = path.join(process.cwd(), 'node_modules');
+  process.chdir(initialCwd);
+}
+
+exports.getNodeModules = function() {
+  if(process.env.CHISEL_MODULES) {
+    return process.env.CHISEL_MODULES;
+  }
+  return node_modules;
+}


### PR DESCRIPTION
This is work in progress PR.

As part of this PR we are moving to travis beta trusty environment. It is necessary because we are using PHP's build-in server instead on Apache to run WordPress.

Currently following are implemented:
* Frontend and WordPress:
  * run `gulp`, open page in phantomjs and check if page is reloading when twig or js file is modified, if js and sourcemap and twig (frontend only) files in dist are properly updated, or if modified CSS and its sourcemap are generated and css file is injected when scss file is modified.
  * run `gulp build` and check if styles, scripts are generated and contains proper links to sourcemaps, normalize-scss and o-list-bare are included in generated css file, assets are copied
* Frontend:
  * [TODO: should be wordpress too] add asset file, run `gulp build`, remove that file, add different file, run `gulp build`, check if first file was removed from dist and second added.

I see now that test for html generation from twigs on build and source maps generation are missing. Let me know what else you think should be tested.

Note: currently to minimize test time we are installing dependencies once and later symlinking them to specific projects, this makes running tests on Windows very problematic. Later if we decide to switch to yarn we may go back to normal installation.