### PR TITLE
Apply adjustments based on the last projects made with Chisel

### DIFF
--- a/generators/app/templates/.stylelintrc.yml
+++ b/generators/app/templates/.stylelintrc.yml
@@ -16,9 +16,8 @@ rules:
   declaration-block-no-shorthand-property-overrides: true
   declaration-block-semicolon-newline-after: always-multi-line
   declaration-block-trailing-semicolon: always
-  declaration-colon-space-after: always
+  declaration-colon-space-after: always-single-line
   declaration-colon-space-before: never
-  declaration-empty-line-before: never
   font-family-name-quotes: always-where-recommended
   function-comma-space-after: always
   function-name-case: lower
@@ -30,7 +29,7 @@ rules:
     - true
     - severity: error
   max-empty-lines: 2
-  max-nesting-depth: 2
+  max-nesting-depth: 3
   no-duplicate-selectors: true
   no-eol-whitespace: true
   no-extra-semicolons: true


### PR DESCRIPTION
Description of changes:

* `declaration-colon-space-after: always-single-line` – makes our life a bit easier when writing things like multiple background or box shadows. [Description](https://stylelint.io/user-guide/rules/declaration-colon-space-after/#always-single-line)
* `declaration-empty-line-before` – removed as was a bit annoying when trying to place scoped variables in a separate block. Example:
  ```scss
  .selector {
    $scopedVariable: 2px;

    width: 100px;
    margin-top: $scopedVariable;
  }
  ```
* `max-nesting-depth: 3` – it's just to make sure that nested media queries won't trigger warnings.