### PR TITLE
Add ignore for VS editor files and local "dist"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ nbproject
 *.sublime-project
 *.sublime-workspace
 .idea
+.vscode
 
 # Folders to ignore
 temp
@@ -40,7 +41,7 @@ tmp
 node_modules
 coverage
 src/bower_components
-dist
+/dist
 
 # Others
 npm-debug.log


### PR DESCRIPTION
If someone uses Visual Studio editors ".vscode" should be added to ignore list. Also folder "dist" should be changed to "/dist", some Wordpress plugins use "dist" folder, so they will be also ignored (i.e. "Yoast SEO")