### PR TITLE
Increase serve performance

### DIFF
--- a/generators/app/templates/gulp/tasks/serve.js
+++ b/generators/app/templates/gulp/tasks/serve.js
@@ -21,6 +21,7 @@ var serveTask = function (gulp, plugins, config, helpers, generator_config) {
       ghostMode: false,
       online: true
     }
+    var themePHPFiles = [path.join(config.dest.wordpress, 'wp-content/themes/', config.dest.wordpressTheme, '**/*.php')];
     <% } else { %>
     var browserSyncConfig = {
       server: './',
@@ -36,7 +37,7 @@ var serveTask = function (gulp, plugins, config, helpers, generator_config) {
     <% } %>
     gulp.watch(path.join(config.src.base, config.src.assets), ['assets-watch']);
     <% if(projectType == 'wp-with-fe') { %>
-    gulp.watch('**/*.{php,twig}').on('change', plugins.browserSync.reload);
+    gulp.watch(config.src.templatesWatch.concat(themePHPFiles)).on('change', plugins.browserSync.reload);
     <% } %>
   });
 };


### PR DESCRIPTION
Line 
```js
gulp.watch('**/*.{php,twig}').on('change', plugins.browserSync.reload);
``` 
makes browserSync to watch all php and twig files within whole project, which in case of Wordpress site has huge impact on performance (in my case CPU is constantly at 60% of usage). I think list of php/twig should be reduced to only those within theme folder, this way serve task is much faster.