### PR TITLE
Replacing selector-no-id with selector-max-id

### DIFF
--- a/generators/app/templates/.stylelintrc.yml
+++ b/generators/app/templates/.stylelintrc.yml
@@ -60,8 +60,8 @@ rules:
   selector-list-comma-space-before: never
   selector-max-compound-selectors: 3
   selector-max-empty-lines: 0
-  selector-no-id:
-    - true
+  selector-max-id:
+    - 0
     - severity: error
   selector-no-qualifying-type:
     - true


### PR DESCRIPTION
Replacing deprecated `selector-no-id` 