### PR TITLE
Rename style guide in app generator instead of wp

### DIFF
--- a/generators/app/utils/generator.js
+++ b/generators/app/utils/generator.js
@@ -53,6 +53,14 @@ var Generator = {
 
     if(this.prompts.hasStyleGuide) {
       helpers.copy.call(this, 'templates/twig/**/*', base, this.prompts);
+
+      if(this.prompts.projectType == 'wp-with-fe') {
+        // Rename style guide so it works as WP page template
+        this.fs.move(
+          this.destinationPath(base + 'style-guide.twig'),
+          this.destinationPath(base + 'page-style-guide.twig')
+        );
+      }
     } else {
       helpers.copy.call(this, 'templates/twig/layouts/*', base + 'layouts/', this.prompts);
       helpers.copy.call(this, 'templates/twig/components/{footer,header}.twig', base + 'components/', this.prompts);

--- a/generators/wp/index.js
+++ b/generators/wp/index.js
@@ -157,14 +157,6 @@ module.exports = class extends Generator {
     this.fs.copy(this.templatePath('images/screenshot.png'),
       this.destinationPath('wp/wp-content/themes/'+this.configuration.nameSlug+'/screenshot.png'));
 
-    // Rename style guide so it works as WP page template
-    if(this.configuration.hasStyleGuide) {
-      this.fs.move(
-        this.destinationPath('wp/wp-content/themes/'+this.configuration.nameSlug+'/templates/style-guide.twig'),
-        this.destinationPath('wp/wp-content/themes/'+this.configuration.nameSlug+'/templates/page-style-guide.twig')
-      );
-    }
-
     this.fs.move(
       this.destinationPath('wp/wp-content/themes/'+this.configuration.nameSlug+'/gitignore'),
       this.destinationPath('wp/wp-content/themes/'+this.configuration.nameSlug+'/.gitignore')


### PR DESCRIPTION
When it's done in wp generator we are moving file that is not actually in the mem-fs and it's seems to not handle that well.

Fix #248