### PR TITLE
Preventing separating numbers within a word when creating slug

### DIFF
--- a/generators/app/utils/prompts.js
+++ b/generators/app/utils/prompts.js
@@ -5,7 +5,7 @@ var path = require('path');
 var limax = require('limax');
 
 function slug(str) {
-  return limax(str).replace(/[^a-z0-9-]/g, '-');
+  return limax(str, {separateNumbers: false}).replace(/[^a-z0-9-]/g, '-');
 }
 
 const FIRST_LETTER = 0;

--- a/test/app/defaults.shared.js
+++ b/test/app/defaults.shared.js
@@ -58,15 +58,15 @@ function addTests() {
   });
 
   it('should generate proper app name in every file', function (done) {
-    assert.fileContent('package.json', '"name": "hello2-waeszorld-2-d"');
-    assert.fileContent('index/project-index.html', 'Project Index - Hello2 Wąęśźorld_2 :D');
+    assert.fileContent('package.json', '"name": "hello2d-waeszorld-2-d"');
+    assert.fileContent('index/project-index.html', 'Project Index - Hello2d Wąęśźorld_2 :D');
 
     done();
   });
 
   it('should create valid Yeoman configuration file', function (done) {
     assert.file('.yo-rc.json');
-    assert.fileContent('.yo-rc.json', '"name": "Hello2 Wąęśźorld_2 :D"');
+    assert.fileContent('.yo-rc.json', '"name": "Hello2d Wąęśźorld_2 :D"');
     assert.fileContent('.yo-rc.json', '"author": "Test Author"');
 
     done();

--- a/test/app/defaults.test.js
+++ b/test/app/defaults.test.js
@@ -13,7 +13,7 @@ describe('Chisel Generator with default options', function () {
         'skip-install': true
       })
       .withPrompts({
-        name: 'Hello2 Wąęśźorld_2 :D',
+        name: 'Hello2d Wąęśźorld_2 :D',
         author: 'Test Author',
         projectType: 'fe',
         styling: 'full_styleguide',

--- a/test/app/styling.full.test.js
+++ b/test/app/styling.full.test.js
@@ -13,7 +13,7 @@ describe('Chisel Generator with default options (except styling set to full)', f
         'skip-install': true
       })
       .withPrompts({
-        name: 'Hello2 Wąęśźorld_2 :D',
+        name: 'Hello2d Wąęśźorld_2 :D',
         author: 'Test Author',
         projectType: 'fe',
         styling: 'full',

--- a/test/app/styling.minimal.test.js
+++ b/test/app/styling.minimal.test.js
@@ -13,7 +13,7 @@ describe('Chisel Generator with default options (except styling set to minimal)'
         'skip-install': true
       })
       .withPrompts({
-        name: 'Hello2 Wąęśźorld_2 :D',
+        name: 'Hello2d Wąęśźorld_2 :D',
         author: 'Test Author',
         projectType: 'fe',
         styling: 'minimal',


### PR DESCRIPTION
This fixes an issue when for project with name `Ab1c` slug was created as `ab-1-c` instead of `ab1c`.