### PR TITLE
Adding Media class to Chisel namespace in WordPress

### DIFF
--- a/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
@@ -15,7 +15,7 @@ class Media {
 		// add_action( 'after_setup_theme', array( $this, 'defaultMediaSetting' ) );
 		// add_filter( 'image_size_names_choose', array( $this, 'customImageSizes' ) );
 		add_action( 'jpeg_quality', array( $this, 'customJpegQuality') );
-		add_filter( 'embed_oembed_html', array( $this, 'customOembedFilter' ), 10, 4);
+		add_filter( 'oembed_dataparse', array( $this, 'customOembedFilter' ), 10, 4);
 	}
 
 	/**
@@ -55,9 +55,12 @@ class Media {
 	}
 
 	/**
-	 * Custom container for content videos
+	 * Custom container for embed content
 	 */
-	function customOembedFilter( $html, $url, $attr, $post_ID ) {
-		return '<div class="c-video">' . $html . '</div>';
+	function customOembedFilter( $html, $data, $url ) {
+		if ( ! is_object( $data ) || empty( $data->type ) ) {
+			return $html;
+		}
+		return '<div class="c-embed c-embed--' . strtolower($data->type) . '">' . $html . '</div>';
 	}
 }

--- a/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
@@ -12,19 +12,19 @@ class Media {
 
 	public function __construct() {
 		// $this->addImageSizes();
-		// add_action('after_setup_theme', array($this, 'defaultMediaSetting'));
-		// add_filter('image_size_names_choose', array($this, 'customImageSizes'));
-		add_action('upload_mimes', array($this, 'customMimeTypes'));
-		add_action('jpeg_quality', array($this, 'customJpegQuality'));
-		add_filter('embed_oembed_html', array($this, 'customOembedFilter'), 10, 4);
+		// add_action( 'after_setup_theme', array( $this, 'defaultMediaSetting' ) );
+		// add_filter( 'image_size_names_choose', array( $this, 'customImageSizes' ) );
+		add_action( 'upload_mimes', array( $this, 'customMimeTypes') );
+		add_action( 'jpeg_quality', array( $this, 'customJpegQuality') );
+		add_filter( 'embed_oembed_html', array( $this, 'customOembedFilter' ), 10, 4);
 	}
 
 	/**
 	 * Add various image sizes
 	 */
 	public function addImageSizes() {
-		add_image_size('small', 225, 9999);
-		add_image_size('800w', 800, 9999);
+		add_image_size( 'small', 225, 9999 );
+		add_image_size( '800w', 800, 9999 );
 	}
 
 	/**
@@ -32,8 +32,8 @@ class Media {
 	 * @param  array $sizes Default sizes
 	 * @return array        Updated sizes
 	 */
-	public function customImageSizes($sizes) {
-		return array_merge($sizes, array(
+	public function customImageSizes( $sizes ) {
+		return array_merge( $sizes, array(
 			'small' => __( 'Small' ),
 		));
 	}
@@ -42,9 +42,9 @@ class Media {
 	 * Default settings when adding or editing post images
 	 */
 	public function defaultMediaSetting() {
-		update_option('image_default_align', 'center');
-		update_option('image_default_link_type', 'none');
-		update_option('image_default_size', 'medium');
+		update_option( 'image_default_align', 'center' );
+		update_option( 'image_default_link_type', 'none' );
+		update_option( 'image_default_size', 'full' );
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Media {
 	 * @param  array $mimes mime types
 	 * @return array        extended mime types
 	 */
-	function customMimeTypes($mimes) {
+	function customMimeTypes( $mimes ) {
 		$mimes['svg'] = 'image/svg+xml';
 		return $mimes;
 	}
@@ -68,9 +68,7 @@ class Media {
 	/**
 	 * Custom container for content videos
 	 */
-	function customOembedFilter($html, $url, $attr, $post_ID) {
-		$return = '<div class="c-video">' . $html . '</div>';
-		return $return;
+	function customOembedFilter( $html, $url, $attr, $post_ID ) {
+		return '<div class="c-video">' . $html . '</div>';
 	}
 }
-

--- a/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
@@ -56,6 +56,11 @@ class Media {
 
 	/**
 	 * Custom container for embed content
+	 *
+	 * oembed_dataparse filter runs when the data is gathered from the oembed provider.
+	 * If you make changes to this filter, already embedded data won't change.
+	 * You need to embed them again or use embed_oembed_html filter which is less performant
+	 * and doesn't provide $data object
 	 */
 	function customOembedFilter( $html, $data, $url ) {
 		if ( ! is_object( $data ) || empty( $data->type ) ) {

--- a/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
@@ -14,7 +14,6 @@ class Media {
 		// $this->addImageSizes();
 		// add_action( 'after_setup_theme', array( $this, 'defaultMediaSetting' ) );
 		// add_filter( 'image_size_names_choose', array( $this, 'customImageSizes' ) );
-		add_action( 'upload_mimes', array( $this, 'customMimeTypes') );
 		add_action( 'jpeg_quality', array( $this, 'customJpegQuality') );
 		add_filter( 'embed_oembed_html', array( $this, 'customOembedFilter' ), 10, 4);
 	}
@@ -45,16 +44,6 @@ class Media {
 		update_option( 'image_default_align', 'center' );
 		update_option( 'image_default_link_type', 'none' );
 		update_option( 'image_default_size', 'full' );
-	}
-
-	/**
-	 * Allowing additional image types
-	 * @param  array $mimes mime types
-	 * @return array        extended mime types
-	 */
-	function customMimeTypes( $mimes ) {
-		$mimes['svg'] = 'image/svg+xml';
-		return $mimes;
 	}
 
 	/**

--- a/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Chisel;
+
+/**
+ * Class Media
+ * @package Chisel
+ *
+ * Default media settings for Chisel
+ */
+class Media {
+
+	public function __construct() {
+		// $this->addImageSizes();
+		// add_action('after_setup_theme', array($this, 'defaultMediaSetting'));
+		// add_filter('image_size_names_choose', array($this, 'customImageSizes'));
+		add_action('upload_mimes', array($this, 'customMimeTypes'));
+		add_action('jpeg_quality', array($this, 'customJpegQuality'));
+		add_filter('embed_oembed_html', array($this, 'customOembedFilter'), 10, 4);
+	}
+
+	/**
+	 * Add various image sizes
+	 */
+	public function addImageSizes() {
+		add_image_size('small', 225, 9999);
+		add_image_size('800w', 800, 9999);
+	}
+
+	/**
+	 * Add custom image sizes option to WP admin
+	 * @param  array $sizes Default sizes
+	 * @return array        Updated sizes
+	 */
+	public function customImageSizes($sizes) {
+		return array_merge($sizes, array(
+			'small' => __( 'Small' ),
+		));
+	}
+
+	/**
+	 * Default settings when adding or editing post images
+	 */
+	public function defaultMediaSetting() {
+		update_option('image_default_align', 'center');
+		update_option('image_default_link_type', 'none');
+		update_option('image_default_size', 'medium');
+	}
+
+	/**
+	 * Allowing additional image types
+	 * @param  array $mimes mime types
+	 * @return array        extended mime types
+	 */
+	function customMimeTypes($mimes) {
+		$mimes['svg'] = 'image/svg+xml';
+		return $mimes;
+	}
+
+	/**
+	 * Sets custom JPG quality when resizing images
+	 * @return number JPG Quality
+	 */
+	public function customJpegQuality() {
+		return 80;
+	}
+
+	/**
+	 * Custom container for content videos
+	 */
+	function customOembedFilter($html, $url, $attr, $post_ID) {
+		$return = '<div class="c-video">' . $html . '</div>';
+		return $return;
+	}
+}
+

--- a/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/Media.php
@@ -11,7 +11,7 @@ namespace Chisel;
 class Media {
 
 	public function __construct() {
-		// $this->addImageSizes();
+		$this->addImagesSizes();
 		// add_action( 'after_setup_theme', array( $this, 'defaultMediaSetting' ) );
 		// add_filter( 'image_size_names_choose', array( $this, 'customImageSizes' ) );
 		add_action( 'jpeg_quality', array( $this, 'customJpegQuality') );
@@ -19,11 +19,11 @@ class Media {
 	}
 
 	/**
-	 * Add various image sizes
+	 * Use this method to register custom image sizes
 	 */
-	public function addImageSizes() {
-		add_image_size( 'small', 225, 9999 );
-		add_image_size( '800w', 800, 9999 );
+	public function addImagesSizes() {
+		// add_image_size( 'small', 225, 9999 );
+		// add_image_size( 'hero', 1600, 9999 );
 	}
 
 	/**

--- a/generators/wp/templates/chisel-starter-theme/Chisel/WpExtensions.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/WpExtensions.php
@@ -17,7 +17,6 @@ class WpExtensions {
 		$this->themeSupport();
 		$this->registerPostTypes();
 		$this->registerTaxonomies();
-		$this->addImagesSizes();
 	}
 
 	public function themeSupport() {
@@ -36,12 +35,5 @@ class WpExtensions {
 	 * Use this method to register custom taxonomies
 	 */
 	public function registerTaxonomies() {
-	}
-
-	/**
-	 * Use this method to register custom image sizes
-	 */
-	public function addImagesSizes() {
-		// add_image_size( 'hero', 3000, 9999 );
 	}
 }

--- a/generators/wp/templates/chisel-starter-theme/functions.php
+++ b/generators/wp/templates/chisel-starter-theme/functions.php
@@ -23,6 +23,7 @@ spl_autoload_register( function ( $class ) {
 if ( \Chisel\Helpers::isTimberActivated() ) {
 	new \Chisel\Security();
 	new \Chisel\Performance();
+	new \Chisel\Media();
 	new \Chisel\TwigExtensions();
 	new \Chisel\WpExtensions();
 	new \Chisel\Site();


### PR DESCRIPTION
This adds `Chisel/Media.php` for various media customization in WP:

- allows to upload SVG to posts
- reduce JPG quality from 90% to 80%
- wraps oembed to `.c-video` 
- allows to add different image sizes and default media settings (commented out by default)

Fixes #265 