### PR TITLE
Add gren config file

### DIFF
--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  "override": true,
+  "username": "xfiveco",
+  "ignoreIssuesWith": [
+    "wontfix",
+    "can't replicate",
+    "chisel ignore",
+    "invalid",
+    "duplicate"
+  ],
+  "template": {
+    "issue": "- [{{text}}]({{url}}) {{name}}"
+  },
+  "groupBy": {
+    "Enhancements:": ["enhancement"],
+    "Fixes:": ["bug"],
+    "Documentation:": ["documentation"]
+  }
+};

--- a/.grenrc.js
+++ b/.grenrc.js
@@ -6,7 +6,8 @@ module.exports = {
     "can't replicate",
     "chisel ignore",
     "invalid",
-    "duplicate"
+    "duplicate",
+    "question"
   ],
   "template": {
     "issue": "- [{{text}}]({{url}}) {{name}}"


### PR DESCRIPTION
Closes #300 

gren config file simplifies usage of [gren](https://github.com/github-tools/github-release-notes/) as it points to `xfiveco` repository, sets ignored labels and a custom template. 