### PR TITLE
Make assets task work properly in dev mode

### DIFF
--- a/generators/app/templates/gulp/tasks/assets.js
+++ b/generators/app/templates/gulp/tasks/assets.js
@@ -9,22 +9,15 @@ module.exports = function assetsTask(gulp, plugins, config) {
     plugins.del([path.join(dest.base, dest.assets)])
   );
 
-  gulp.task('assets-build', ['assets-clean'], () =>
-    gulp
+  function assets() {
+    return gulp
       .src([path.join(src.base, src.assets), '!**/.keep'], {
         base: src.base,
       })
       .pipe(gulp.dest(dest.base))
-      .on('end', plugins.browserSync.reload)
-  );
+      .on('end', plugins.browserSync.reload);
+  }
 
-  gulp.task('assets-watch', () =>
-    gulp
-      .src([path.join(src.base, src.assets), '!**/.keep'], {
-        base: src.base,
-      })
-      .pipe(plugins.newer(dest.base))
-      .pipe(gulp.dest(dest.base))
-      .on('end', plugins.browserSync.reload)
-  );
+  gulp.task('assets-build', ['assets-clean'], () => assets());
+  gulp.task('assets-watch', ['assets-clean'], () => assets());
 };

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -64,7 +64,6 @@
     "gulp-htmlhint": "^0.3.1",
     "gulp-load-plugins": "^1.5.0",
     "gulp-mirror": "^1.0.0",
-    "gulp-newer": "^1.3.0",
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^7.0.0",
     "gulp-prettify": "^0.5.0",


### PR DESCRIPTION
Closes #339 

Assets task now should work in the same way in dev mode like during build - cleans `assets/dist` and copies files. This also removes `gulp-newer` dependency which isn't used anywhere else. If we later want to do some more heavy processing tasks like image optimization, we can reimplement `newer` to assets watch, but for now this should ensure that assets are properly copied in dev mode too.