### PR TITLE
Update .htmlhintrc - add preserveAspectRatio to ignored attributs

### DIFF
--- a/generators/app/templates/.htmlhintrc
+++ b/generators/app/templates/.htmlhintrc
@@ -1,3 +1,3 @@
 {
-  "attr-lowercase": ["viewBox"]
+  "attr-lowercase": ["viewBox", "preserveAspectRatio"]
 }


### PR DESCRIPTION
When I am using inline SVG with preserveAspectRatio attribute, I get multiple warnings about it not being lowercase. Please add it to ignored attributes.