### PR TITLE
Update breakpoints

### DIFF
--- a/generators/app/templates/styles/itcss/elements/_html.scss
+++ b/generators/app/templates/styles/itcss/elements/_html.scss
@@ -25,15 +25,15 @@ html {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 
-  @include bp-medium {
+  @include bp(medium) {
     font-size: 0.875em; /* 14px */
   }
 
-  @include bp-large {
+  @include bp(large) {
     font-size: 0.9375em; /* 15px */
   }
 
-  @include bp-full {
+  @include bp(full) {
     font-size: 1em; /* 16px */
   }
 }

--- a/generators/app/templates/styles/itcss/objects/_layout.scss
+++ b/generators/app/templates/styles/itcss/objects/_layout.scss
@@ -7,7 +7,7 @@
 .o-layout {
   display: block;
 
-  @include bp-medium {
+  @include bp(medium) {
     display: flex;
   }
 }
@@ -26,7 +26,7 @@
 
 .o-layout--2 {
   > .o-layout__item {
-    @include bp-medium {
+    @include bp(medium) {
       width: 49%;
     }
   }
@@ -34,7 +34,7 @@
 
 .o-layout--3 {
   > .o-layout__item {
-    @include bp-medium {
+    @include bp(medium) {
       width: 32%;
     }
   }
@@ -42,7 +42,7 @@
 
 .o-layout--4 {
   > .o-layout__item {
-    @include bp-medium {
+    @include bp(medium) {
       width: 24%;
     }
   }

--- a/generators/app/templates/styles/itcss/settings/_global.scss
+++ b/generators/app/templates/styles/itcss/settings/_global.scss
@@ -16,11 +16,14 @@ $font-sans-serif: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI',
 /* Breakpoints
    ========================================================================== */
 
-$bp-small: 480px;
-$bp-medium: 768px;
-$bp-large: 1024px;
-$bp-xlarge: 1280px;
-$bp-full: 1600px;
+$breakpoints: (
+  small: 480px,
+  medium: 768px,
+  large: 1024px,
+  xlarge: 1280px,
+  full: 1600px,
+);
+
 
 /* Colors
    ========================================================================== */

--- a/generators/app/templates/styles/itcss/tools/_breakpoints.scss
+++ b/generators/app/templates/styles/itcss/tools/_breakpoints.scss
@@ -3,19 +3,27 @@
 //   ======================================================================== */
 
 @function bp-val($name) {
+  @if type-of($name) == 'number' {
+    @return $name;
+  }
+
   $val: map-get($breakpoints, $name);
+
   @if $val == null {
     @error 'Breakpoint #{$name} not found';
   }
+
   @return $val;
 }
 
 @function bp-val-next($name) {
   $breakpoint-names: map_keys($breakpoints);
   $n: index($breakpoint-names, $name);
+
   @if $n >= length($breakpoint-names) {
     @error 'Next breakpoint after #{$name} not found';
   }
+
   $next-key: nth($breakpoint-names, $n + 1);
   @return map-get($breakpoints, $next-key);
 }
@@ -37,6 +45,10 @@
 }
 
 @mixin bp-only($name) {
+  @if type-of($name) == 'number' {
+    @error '#{$name} should be breakpoint name';
+  }
+
   $min: bp-val($name);
   $max: bp-val-next($name);
 

--- a/generators/app/templates/styles/itcss/tools/_breakpoints.scss
+++ b/generators/app/templates/styles/itcss/tools/_breakpoints.scss
@@ -2,32 +2,54 @@
 //   #BREAKPOINTS
 //   ======================================================================== */
 
-@mixin bp-small {
-  @media (min-width: $bp-small) {
+@function bp-val($name) {
+  $val: map-get($breakpoints, $name);
+  @if $val == null {
+    @error 'Breakpoint #{$name} not found';
+  }
+  @return $val;
+}
+
+@function bp-val-next($name) {
+  $breakpoint-names: map_keys($breakpoints);
+  $n: index($breakpoint-names, $name);
+  @if $n >= length($breakpoint-names) {
+    @error 'Next breakpoint after #{$name} not found';
+  }
+  $next-key: nth($breakpoint-names, $n + 1);
+  @return map-get($breakpoints, $next-key);
+}
+
+@mixin bp($name) {
+  $val: bp-val($name);
+
+  @media (min-width: $val) {
     @content;
   }
 }
 
-@mixin bp-medium {
-  @media (min-width: $bp-medium) {
+@mixin bp-down($name) {
+  $val: bp-val($name);
+
+  @media (max-width: $val - 0.02) {
     @content;
   }
 }
 
-@mixin bp-large {
-  @media (min-width: $bp-large) {
+@mixin bp-only($name) {
+  $min: bp-val($name);
+  $max: bp-val-next($name);
+
+  @media (min-width: $min) and (max-width: $max - 0.02) {
     @content;
   }
 }
 
-@mixin bp-xlarge {
-  @media (min-width: $bp-xlarge) {
-    @content;
-  }
-}
+@mixin bp-between($name1, $name2) {
+  $min: bp-val($name1);
+  $max: bp-val($name2);
 
-@mixin bp-full {
-  @media (min-width: $bp-full) {
+  @media (min-width: $min) and (max-width: $max - 0.02) {
     @content;
   }
 }

--- a/generators/app/templates/styles/itcss/utilities/_hide.scss
+++ b/generators/app/templates/styles/itcss/utilities/_hide.scss
@@ -22,7 +22,7 @@
 .u-hidden\@small {
   display: none;
 
-  @include bp-medium {
+  @include bp(medium) {
     display: block;
   }
 }


### PR DESCRIPTION
Fixes #391 

This PR:
* replaces `bp-*` misins with one `bp(*)` mix, removing necessity for separated mixins for each breakpoint,
* adds `bp-down(*)` mixin that is generating `(max-width: *)` media query
* adds `bp-only(*)` mixin
* adds `bp-between(*, *)` mixin

All mixins except `bp-only` support custom values.

CC: @piotr-bajer please take a look