### PR TITLE
Remove srcset function in Image class

### DIFF
--- a/generators/wp/templates/chisel-starter-theme/Chisel/Image.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/Image.php
@@ -15,17 +15,6 @@ class Image extends \Timber\Image {
 	public $PostClass = 'Chisel\Post';
 
 	/**
-	 * @inheritDoc
-	 */
-	public function srcset($size = "full") {
-		if (!$this->is_image()) {
-			return '';
-		}
-
-		return wp_get_attachment_image_srcset($this->ID);
-	}
-
-	/**
 	 * Checks whether attachment is an image. Duplicate from \Timber\Image due to @internal flag.
 	 *
 	 * @internal


### PR DESCRIPTION
Currently, the `srcset` does the same as the parent version. Also, it has a bug because `$size` parameter is used anywhere.