### PR TITLE
Add new wp_body_open action

### DIFF
--- a/generators/app/templates/templates/twig/layouts/base.twig
+++ b/generators/app/templates/templates/twig/layouts/base.twig
@@ -26,6 +26,9 @@
 </head>
 
 <body class="{{body_class}}">
+  <% if (projectType == 'wp-with-fe') { %>
+  {{ function('wp_body_open') }}<% } %>
+
   {% block header %}
     {% include 'components/header.twig' %}
   {% endblock %}


### PR DESCRIPTION
Hi, Since WP 5.2 there is new action `wp_body_open` to be used after `<body>` tag. I predict some plugins might use that i.e. to insert Google Tag Manager, can we add it to the base layout?