### PR TITLE
Remove Timber Image overriding

### DIFF
--- a/generators/wp/templates/chisel-starter-theme/Chisel/Extensions/ChiselTwig.php
+++ b/generators/wp/templates/chisel-starter-theme/Chisel/Extensions/ChiselTwig.php
@@ -57,15 +57,6 @@ class ChiselTwig extends Twig {
 
 		$this->registerFunction(
 			$twig,
-			'Image',
-			array(
-				$this,
-				'chiselImage',
-			)
-		);
-
-		$this->registerFunction(
-			$twig,
 			'hasVendor'
 		);
 


### PR DESCRIPTION
Hi, I think we should remove the Image override because it produces following Notice:

`PHP Deprecated: Overriding function "Image" that is already registered is deprecated since version 1.30 and won't be possible anymore in 2.0. in /superdisk/wp/wp-content/plugins/timber-library/vendor/twig/twig/src/Extension/StagingExtension.php on line 38`