### PR TITLE
Fix Eslint import error (#493)

### DIFF
--- a/packages/generator-chisel/lib/commands/create/creators/app/template/.eslintrc.js
+++ b/packages/generator-chisel/lib/commands/create/creators/app/template/.eslintrc.js
@@ -1,5 +1,5 @@
 process.env.CHISEL_CONTEXT = __dirname;
-const chiselConfig = require('./chisel.config.js');
+const chiselConfig = require('./chisel.config');
 
 let extend = 'chisel';
 

--- a/packages/generator-chisel/lib/commands/create/creators/app/template/babel.config.js
+++ b/packages/generator-chisel/lib/commands/create/creators/app/template/babel.config.js
@@ -1,4 +1,4 @@
-const chiselConfig = require('./chisel.config.js');
+const chiselConfig = require('./chisel.config');
 
 module.exports = {
   presets: [


### PR DESCRIPTION
I have removed the `.js` extension from require. More info in [import/extensions](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md)