### PR TITLE
Fix devcontainer bootstrap, setup docs, and HMR WebSocket path

### DIFF
--- a/packages/chisel-scripts/index.js
+++ b/packages/chisel-scripts/index.js
@@ -98,9 +98,12 @@ function adjustWebpackConfig(baseConfig, directory) {
           port: Number(process.env.CHISEL_PORT) + 1,
           client: {
             ...devSeverClient,
-            webSocketURL: new URL(getUrl())
-              .toString()
-              .replace(process.env.CHISEL_PORT, Number(process.env.CHISEL_PORT) + 1),
+            webSocketURL: (() => {
+              const url = new URL(getUrl());
+              url.port = Number(process.env.CHISEL_PORT) + 1;
+              url.pathname = '/ws';
+              return url.toString();
+            })(),
           },
         }),
         setupMiddlewares: (middlewares, devServer) => {

--- a/packages/generator-chisel/lib/commands/create/creators/app/chisel-starter-theme/README.md
+++ b/packages/generator-chisel/lib/commands/create/creators/app/chisel-starter-theme/README.md
@@ -11,8 +11,8 @@ Use Node.js version `24.11.1` (Minimum `20.12.2`)
 Chisel is installed as a npm package using npx command: `npx generator-chisel`, which scaffolds the entire project for you including composer and node dependencies, however when you join the project and clone the repository, follow these steps to start the local development:
 
 1. Go to the theme folder
-2. Run `composer install`
-3. Run `npm install`
+2. Run `npm install`
+3. Run `npm run composer install`
 4. Copy `wp-config-custom.php` and rename it to `wp-config.php` in the project root directory (if you haven't done so already).
 5. Run `npm run wp-config`
 

--- a/packages/generator-chisel/lib/commands/create/creators/app/template/.devcontainer/post-create-command.sh.chisel-tpl
+++ b/packages/generator-chisel/lib/commands/create/creators/app/template/.devcontainer/post-create-command.sh.chisel-tpl
@@ -7,6 +7,7 @@ touch .use-devcontainer
 
 pushd ../../..
 
+sudo touch wp-config.php
 sudo chown "$USER:$USER" . index.php wp-config.php
 if [ -d .git ] ; then sudo chown "$USER:$USER" .git ; fi
 chmod +x .devcontainer/compose .devcontainer/exec


### PR DESCRIPTION
## Summary
- Create `wp-config.php` before the devcontainer post-create script chowns it
- Update setup docs to install npm dependencies before running Composer through the npm script
- Point the Webpack client WebSocket URL to `/ws` on the dev-server port when `CHISEL_PORT` is used